### PR TITLE
simplified API

### DIFF
--- a/assets/prefabs/SignalLampOff.prefab
+++ b/assets/prefabs/SignalLampOff.prefab
@@ -3,6 +3,6 @@
 
     },
     "SignalLeaf":{
-        "inputs": 63
+        "inputs": ["LEFT","RIGHT","FRONT","BACK","TOP","BOTTOM"]
     }
 }

--- a/assets/prefabs/SignalLampOn.prefab
+++ b/assets/prefabs/SignalLampOn.prefab
@@ -3,6 +3,6 @@
 
     },
     "SignalLeaf":{
-        "inputs": 63
+        "inputs": ["LEFT","RIGHT","FRONT","BACK","TOP","BOTTOM"]
     }
 }

--- a/assets/prefabs/SignalSwitch.prefab
+++ b/assets/prefabs/SignalSwitch.prefab
@@ -1,6 +1,6 @@
 {
     "SignalLeaf":{
-        "outputs": 63
+        "outputs": ["LEFT","RIGHT","FRONT","BACK","TOP","BOTTOM"]
     },
     "ToggleSwitch" : {
 

--- a/assets/prefabs/gate/SignalAndGate.prefab
+++ b/assets/prefabs/gate/SignalAndGate.prefab
@@ -1,7 +1,7 @@
 {
     "SignalLeaf":{
-        "inputs": 59,
-        "outputs": 4
+        "inputs": ["BACK","LEFT","RIGHT","TOP","BOTTOM"],
+        "outputs": ["FRONT"]
     },
     "AndGate": {}
 }

--- a/assets/prefabs/gate/SignalNotGate.prefab
+++ b/assets/prefabs/gate/SignalNotGate.prefab
@@ -1,7 +1,7 @@
 {
     "SignalLeaf":{
-        "inputs": 32,
-	        "outputs": 4
+        "inputs":["BACK"],
+       "outputs": ["FRONT"]
     },
     "NotGate": {}
 }

--- a/assets/prefabs/gate/SignalOrGate.prefab
+++ b/assets/prefabs/gate/SignalOrGate.prefab
@@ -1,7 +1,7 @@
 {
   "SignalLeaf":{
-        "inputs": 59,
-        "outputs": 4
+        "inputs": ["BACK","LEFT","RIGHT","TOP","BOTTOM"],
+        "outputs": ["FRONT"]
     },
     "OrGate": {}
 }

--- a/assets/prefabs/gate/SignalXorGate.prefab
+++ b/assets/prefabs/gate/SignalXorGate.prefab
@@ -1,7 +1,7 @@
 {
   "SignalLeaf":{
-        "inputs": 59,
-        "outputs": 4
+        "inputs": ["BACK","LEFT","RIGHT","TOP","BOTTOM"],
+        "outputs": ["FRONT"]
     },
     "XorGate": {}
 }

--- a/src/main/java/org/terasology/signalling/action/GateAction.java
+++ b/src/main/java/org/terasology/signalling/action/GateAction.java
@@ -21,7 +21,6 @@ import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.math.Side;
-import org.terasology.math.SideBitFlag;
 import org.terasology.registry.In;
 import org.terasology.signalling.componentSystem.SignalSystem;
 import org.terasology.signalling.components.SignalLeafComponent;
@@ -39,62 +38,63 @@ public class GateAction extends BaseComponentSystem {
     private SignalSystem signalSystem;
 
     @ReceiveEvent(components = {BlockComponent.class, XorGateComponent.class, SignalLeafComponent.class})
-    public void signalXorChange(LeafNodeSignalChange event, EntityRef entity, BlockComponent blockComponent, XorGateComponent xorGateComponent) {
+    public void signalXorChange(LeafNodeSignalChange event, EntityRef entity,SignalLeafComponent signalLeafComponent, BlockComponent blockComponent, XorGateComponent xorGateComponent) {
         if (event.getInputs().size() % 2 == 1) {
             // An odd number of inputs are active: Output HIGH.
-            for (Side side : SideBitFlag.getSides(signalSystem.getConnectedOutputs(entity))) {
+            for (Side side : signalLeafComponent.outputs) {
                 signalSystem.setLeafOutput(entity, side, xorGateComponent.strength, xorGateComponent.delay);
             }
         } else {
             // An even number of inputs are active: Output LOW. Note that this includes 0 active inputs.
-            for (Side side : SideBitFlag.getSides(signalSystem.getConnectedOutputs(entity))) {
+            for (Side side : signalLeafComponent.outputs) {
                 signalSystem.setLeafOutput(entity, side, (byte) 0, xorGateComponent.delay);
             }
         }
     }
 
     @ReceiveEvent(components = {BlockComponent.class, AndGateComponent.class, SignalLeafComponent.class})
-    public void signalAndChange(LeafNodeSignalChange event, EntityRef entity, BlockComponent blockComponent, AndGateComponent andGateComponent) {
-        if (event.getInputs().size() == SideBitFlag.getSides(signalSystem.getConnectedInputs(entity)).size() && event.getInputs().size() != 0) {
+    public void signalAndChange(LeafNodeSignalChange event, EntityRef entity,SignalLeafComponent signalLeafComponent, BlockComponent blockComponent, AndGateComponent andGateComponent) {
+
+
+        if (event.getInputs().size() == signalSystem.getActiveSides(entity,signalLeafComponent.inputs).size() && event.getInputs().size() != 0) {
             // More than one input is connected, and all of them are HIGH: Output HIGH.
-            for (Side side : SideBitFlag.getSides(signalSystem.getConnectedOutputs(entity))) {
+            for (Side side : signalLeafComponent.outputs) {
                 signalSystem.setLeafOutput(entity, side, andGateComponent.strength, andGateComponent.delay);
             }
         } else {
             // No input is connected, or one of the connected inputs is LOW: Output LOW.
-            for (Side side : SideBitFlag.getSides(signalSystem.getConnectedOutputs(entity))) {
+            for (Side side : signalLeafComponent.outputs) {
                 signalSystem.setLeafOutput(entity, side, (byte) 0, andGateComponent.delay);
             }
         }
     }
 
     @ReceiveEvent(components = {BlockComponent.class, OrGateComponent.class, SignalLeafComponent.class})
-    public void signalOrChange(LeafNodeSignalChange event, EntityRef entity, BlockComponent blockComponent, OrGateComponent orGateComponent) {
+    public void signalOrChange(LeafNodeSignalChange event, EntityRef entity,SignalLeafComponent signalLeafComponent, BlockComponent blockComponent, OrGateComponent orGateComponent) {
         if (event.getInputs().size() > 0) {
             // At least one input is HIGH: Output HIGH.
-            for (Side side : SideBitFlag.getSides(signalSystem.getConnectedOutputs(entity))) {
+            for (Side side : signalLeafComponent.outputs) {
                 signalSystem.setLeafOutput(entity, side, orGateComponent.strength, orGateComponent.delay);
             }
         } else {
             // No input is connected, or all inputs are LOW: Output LOW.
-            for (Side side : SideBitFlag.getSides(signalSystem.getConnectedOutputs(entity))) {
+            for (Side side : signalLeafComponent.outputs) {
                 signalSystem.setLeafOutput(entity, side, (byte) 0, orGateComponent.delay);
             }
         }
     }
 
     @ReceiveEvent(components = {BlockComponent.class, NotGateComponent.class, SignalLeafComponent.class})
-    public void signalNotChange(LeafNodeSignalChange event, EntityRef entity, BlockComponent blockComponent, NotGateComponent notGateComponent) {
-        final int SIDE_BACK = 32;
-        if (signalSystem.getUntransformedConnectedInputs(entity) == SIDE_BACK && event.getInputs().size() == 0) {
-            // One LOW input: output HIGH.
-            for (Side side : SideBitFlag.getSides(signalSystem.getConnectedOutputs(entity))) {
-                signalSystem.setLeafOutput(entity, side, notGateComponent.strength, notGateComponent.delay);
+    public void signalNotChange(LeafNodeSignalChange event, EntityRef entity,SignalLeafComponent signalLeafComponent, BlockComponent blockComponent, NotGateComponent notGateComponent) {
+        if (event.getInputs().size() > 0) {
+            // Either a HIGH input, or no input at all: Output LOW.
+            for (Side side : signalLeafComponent.outputs) {
+                signalSystem.setLeafOutput(entity, side, (byte) 0, notGateComponent.delay);
             }
         } else {
-            // Either a HIGH input, or no input at all: Output LOW.
-            for (Side side : SideBitFlag.getSides(signalSystem.getConnectedOutputs(entity))) {
-                signalSystem.setLeafOutput(entity, side, (byte) 0, notGateComponent.delay);
+            // One LOW input: output HIGH.
+            for (Side side : signalLeafComponent.outputs) {
+                signalSystem.setLeafOutput(entity, side, notGateComponent.strength, notGateComponent.delay);
             }
         }
     }

--- a/src/main/java/org/terasology/signalling/action/SignalSwitchAction.java
+++ b/src/main/java/org/terasology/signalling/action/SignalSwitchAction.java
@@ -39,11 +39,11 @@ public class SignalSwitchAction extends BaseComponentSystem {
     public void signalActivated(ActivateEvent event, EntityRef entity, ToggleSwitchComponent signalSwitchComponent, SignalLeafComponent leafNodeComponent) {
         signalSwitchComponent.isActive = !signalSwitchComponent.isActive;
         if (signalSwitchComponent.isActive) {
-            for (Side side : SideBitFlag.getSides(leafNodeComponent.outputs)) {
+            for (Side side : leafNodeComponent.outputs) {
                 signalSystem.setLeafOutput(entity, side, signalSwitchComponent.strength);
             }
         } else {
-            for (Side side : SideBitFlag.getSides(leafNodeComponent.outputs)) {
+            for (Side side : leafNodeComponent.outputs) {
                 signalSystem.setLeafOutput(entity, side, (byte) 0);
             }
         }

--- a/src/main/java/org/terasology/signalling/blockFamily/SignalCableBlockFamily.java
+++ b/src/main/java/org/terasology/signalling/blockFamily/SignalCableBlockFamily.java
@@ -89,8 +89,14 @@ public class SignalCableBlockFamily extends MultiConnectFamily {
         if (entityRef.hasComponent(SignalLeafComponent.class)) {
             SignalLeafComponent leafNodeComponent = entityRef.getComponent(SignalLeafComponent.class);
 
-            for (Side side : SideBitFlag.getSides(signalSystem.getAllConnections(entityRef))) {
-                if (side == connectSide.reverse()) {
+            for (Side side : leafNodeComponent.inputs) {
+                if (signalSystem.getTransformedSide(entityRef,side)== connectSide.reverse()) {
+                    return true;
+                }
+            }
+
+            for (Side side : leafNodeComponent.outputs) {
+                if (signalSystem.getTransformedSide(entityRef,side)== connectSide.reverse()) {
                     return true;
                 }
             }

--- a/src/main/java/org/terasology/signalling/componentSystem/SignalStateSystem.java
+++ b/src/main/java/org/terasology/signalling/componentSystem/SignalStateSystem.java
@@ -29,6 +29,7 @@ import org.terasology.math.SideBitFlag;
 import org.terasology.registry.In;
 import org.terasology.signalling.components.CableComponent;
 import org.terasology.signalling.components.SignalLeafComponent;
+import org.terasology.world.OnChangedBlock;
 import org.terasology.world.WorldProvider;
 import org.terasology.world.block.Block;
 import org.terasology.world.block.BlockComponent;

--- a/src/main/java/org/terasology/signalling/componentSystem/SignalSystem.java
+++ b/src/main/java/org/terasology/signalling/componentSystem/SignalSystem.java
@@ -26,7 +26,6 @@ import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.entitySystem.systems.UpdateSubscriberSystem;
 import org.terasology.logic.config.ModuleConfigManager;
-import org.terasology.math.Rotation;
 import org.terasology.math.Side;
 import org.terasology.math.SideBitFlag;
 import org.terasology.math.geom.Vector3i;
@@ -133,7 +132,11 @@ public class SignalSystem extends BaseComponentSystem implements UpdateSubscribe
             if (signalStateComponent.outputs[SignalStateComponent.OUTPUT_SIDES.indexOf(getTransformedSide(entityRef,side))] == strength)
                 return true;
 
-            delays.add(new SignalDelayHandler(delay, time.getGameTimeInMs(), entityRef, strength, side));
+            SignalDelayHandler handler = new SignalDelayHandler(delay, time.getGameTimeInMs(), entityRef, strength, side);
+            if(delays.contains(handler)){
+                delays.remove(handler);
+            }
+            delays.add(handler);
             return true;
 
         }
@@ -294,6 +297,15 @@ public class SignalSystem extends BaseComponentSystem implements UpdateSubscribe
             return currentTime + delta;
         }
 
+        @Override
+        public boolean equals(Object o) {
+            return o instanceof SignalDelayHandler && ((SignalDelayHandler) o).side == side && ((SignalDelayHandler) o).entityRef.equals(entityRef);
+        }
+
+        @Override
+        public int hashCode() {
+            return entityRef.hashCode() + 31 * side.getVector3i().hashCode();
+        }
     }
 
     public static class SignalDelayComparitor implements Comparator<SignalDelayHandler> {

--- a/src/main/java/org/terasology/signalling/components/SignalLeafComponent.java
+++ b/src/main/java/org/terasology/signalling/components/SignalLeafComponent.java
@@ -16,9 +16,13 @@
 package org.terasology.signalling.components;
 
 import org.terasology.entitySystem.Component;
+import org.terasology.math.Side;
+
+import java.util.EnumSet;
+import java.util.Set;
 
 public class SignalLeafComponent implements Component {
-    public byte outputs = 0;
-    public byte inputs = 0;
+    public Set<Side> outputs = EnumSet.noneOf(Side.class);
+    public Set<Side> inputs = EnumSet.noneOf(Side.class);
 }
 


### PR DESCRIPTION
here is a rework of the API. I basically just removed all the side helper functions and just left the side transformation up to the end developer of the module. The general logic isn't too complicate and I think the helper functions actually make the whole thing more complicated. 

With this pr https://github.com/MovingBlocks/Terasology/commit/c361c8030b36035415840d567d8d66fed08006ea. It's now possible to use a list of enums in a prefab. This should also improve the usability of the module.